### PR TITLE
Standardise delete behaviour over sftp

### DIFF
--- a/git-ftp
+++ b/git-ftp
@@ -795,7 +795,7 @@ handle_remote_protocol_options() {
 		fi
 		
 		# SFTP uses a different remove command and uses absolute paths
-		REMOTE_DELETE_CMD="rm /"
+		REMOTE_DELETE_CMD="-*rm /"
 	fi
 
 	# Check for using cacert


### PR DESCRIPTION
With ftp the delete command uses the non-terminating-on-error form: `-*DELE`. Whereas the sftp command uses the `rm` command which terminates on error.

This commit updates the sftp command to use the equivalent behaviour: `-*rm`.

Ref: http://linux.die.net/man/1/sftp
